### PR TITLE
Remove maybe from fuzzer

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1005,7 +1005,8 @@ impl fmt::Display for Module {
             } else {
                 ""
             },
-            if config.disable_maybe {
+            // if config.disable_maybe {
+            if false {
                 "--disable-maybe "
             } else {
                 ""
@@ -1032,7 +1033,8 @@ impl fmt::Display for Module {
             f,
             "% then complete with `--tmp-directory <OUT> --minimized-directory <MINIMIZED> --command <COMMAND>` where command is the script that you used (e.g. ./verify_erlc_opts.sh)\n"
         )?;
-        if !config.disable_maybe {
+        // if !config.disable_maybe {
+        if false {
             write!(f, "-feature(maybe_expr, enable).\n")?;
         }
         write!(f, "-module({}).\n", self.module_name)?;

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,7 +41,8 @@ impl Context {
         Context {
             allowed_size: config.max_size,
             max_recursion_depth: config.max_recursion_depth,
-            maybe_is_allowed: !config.disable_maybe,
+            // maybe_is_allowed: !config.disable_maybe,
+            maybe_is_allowed: false,
             map_comprehensions_are_allowed: !config.disable_map_comprehensions,
             deterministic: config.deterministic,
             ..Context::new()

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -177,6 +177,7 @@ fn gen_start_function<RngType: rand::Rng>(
         let call = module.add_expr(Expr::LocalCall(name, args), Any);
         exprs.push(module.add_expr(Expr::Catch(call), Any));
     }
+    exprs.push(module.add_expr(Expr::Atom("ok".to_string()), Atom));
     let body = module.add_body(Body { exprs });
     let name = "start".to_owned();
     make_trivial_function_from_body(module, body, name)


### PR DESCRIPTION
--disable-maybe wasn't working sometimes
Added `ok` at the end of entrypoint to remove various crashes that weren't really crashes.